### PR TITLE
修复 "unexpected keyword argument" 导致的服务无法运行的问题

### DIFF
--- a/ftp_v5/cos_file_system.py
+++ b/ftp_v5/cos_file_system.py
@@ -65,11 +65,12 @@ class CosFileSystem(AbstractedFS):
     def __init__(self, *args, **kwargs):
         super(CosFileSystem, self).__init__(*args, **kwargs)
         self._cos_client = CosS3Client(CosConfig(Region=CosFtpConfig().get_user_info(self.root)['cos_region'],
-                                                 Endpoint=CosFtpConfig().get_user_info(self.root)['cos_endpoint'],
+                                                 # Endpoint=CosFtpConfig().get_user_info(self.root)['cos_endpoint'],
                                                  Scheme=CosFtpConfig().get_user_info(self.root)['cos_protocol'],
                                                  Access_id=CosFtpConfig().get_user_info(self.root)["cos_secretid"],
                                                  Access_key=CosFtpConfig().get_user_info(self.root)['cos_secretkey'],
-                                                 UA=version.user_agent),
+                                                 # UA=version.user_agent
+                                                 ),
                                        retry=3)
         self._bucket_name = CosFtpConfig().get_user_info(self.root)["bucket"]
 


### PR DESCRIPTION
/cos-ftp-server-V5/ftp_v5/cos_file_system.py 中 初始化对象的时候，传入了 "unexpected keyword argument" ，将导致ftp服务无法连接，具体报错如下：
```
  File "/root/cos-ftp-server-V5/ftp_v5/cos_file_system.py", line 73, in __init__
    UA=version.user_agent),
TypeError: __init__() got an unexpected keyword argument 'Endpoint'


  File "/root/cos-ftp-server-V5/ftp_v5/cos_file_system.py", line 72, in __init__
    UA=version.user_agent),
TypeError: __init__() got an unexpected keyword argument 'UA'
```

我暂时将相关的行注释掉了，后续如果支持了这两个参数的话，可以再打开