### PR TITLE
fix: 多次上传失败后进程卡死

### DIFF
--- a/ftp_v5/upload_pool.py
+++ b/ftp_v5/upload_pool.py
@@ -15,7 +15,12 @@ class UploadThread(threading.Thread):
         self.__callback = callback
 
     def run(self):
-        super(UploadThread, self).run()
+        try:
+            super(UploadThread, self).run()
+        except Exception as e:
+            logger.info("Thread {0} throw exception \"{1}\"".format(threading.currentThread().getName(), e))
+            self.__callback()
+            raise e
         self.__callback()
 
 


### PR DESCRIPTION
复现路径：
1. 在 multipart_upload.py:upload_part 这里注入错误`a = 1 / 0`，模拟网络上传中断开的场景
```
    def upload_part(self, content, part_num, callback=None):
        dict_response = None
        try:
            a = 1 / 0
            dict_response = self._cos_client.upload_part(
                Bucket=self._bucket_name, Key=self._key_name,
                UploadId=self._upload_id, PartNumber=part_num,
                Body=content
            )
        except Exception as e:
            if callback is not None:
                callback(part_num, False)  # 如果上传成功，需要回调通知
                raise e
```
2. 为了方便复现，把配置的 upload_thread_num   改成 1
3. 上传一个较大一点的文件，这里测试的是 70MB 的文件
4. 上传报错
5. 尝试再次连接 ftp 服务器卡住:
```
Status:      	Connecting to 127.0.0.1:2121...
Status:      	Connection established, waiting for welcome message...
Command:	PASV
Response: 	227 Entering passive mode (127,0,0,1,239,237).
Command:	STOR trunk_Translation.xls
Response: 	150 File status okay. About to open data connection.
Error:        	Connection timed out after 20 seconds of inactivity
Error:        	File transfer failed after transferring 21.9 MB in 25 seconds
Status:      	Connecting to 127.0.0.1:2121...
Status:      	Connection established, waiting for welcome message...
Error:        	Connection timed out after 20 seconds of inactivity
Error:        	File transfer failed
```
上传后抛出注入的错误，UploadPool.release 没有调用导致锁没有释放
这时候整个进程就卡死了，直接无法建立 ftp 连接

问题初步定位：
UploadPool._semaphore 在上传失败后未释放，导致后续的上传一直等待
**暂未定位到为何影响到 ftp 连接建立**